### PR TITLE
Update syncany.desktop to fix auto starting

### DIFF
--- a/gradle/debian/syncany-plugin-gui/usr/share/applications/syncany.desktop
+++ b/gradle/debian/syncany-plugin-gui/usr/share/applications/syncany.desktop
@@ -2,7 +2,7 @@
 Name=Syncany
 GenericName=Syncany
 Comment=Securely sync files to the cloud
-Exec=sy gui
+Exec=syncany gui
 Terminal=false
 Type=Application
 Icon=syncany


### PR DESCRIPTION
"sy" is not aliased to "syncany" via the default install. So the "Exec=sy gui" auto start option fails when starting my Arch Linux system. I propose that the full path of the executable is used instead of an alias so that it always works.